### PR TITLE
add downlevelIteration compiler option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "strictFunctionTypes": true,
     "noUnusedParameters": true,
     "preserveConstEnums": true,
+    "downlevelIteration": true,
     "removeComments": true,
     "typeRoots": [
       "node_modules/@types"


### PR DESCRIPTION
There are some compatibility issues with older IOS and android because of the object destructuring spread operator.

This compiler option seems to resolve the issue. https://www.typescriptlang.org/docs/handbook/compiler-options.html